### PR TITLE
add option for ISO keyboard layout

### DIFF
--- a/src/button-accordion-with-keyboard/consts/keyboardLayout.ts
+++ b/src/button-accordion-with-keyboard/consts/keyboardLayout.ts
@@ -1,5 +1,5 @@
 // キーボードレイアウトの種類
-export type KeyboardLayoutType = "en" | "ja";
+export type KeyboardLayoutType = "en" | "iso" | "ja";
 
 // キーボードレイアウト（英語キーボード）
 export const EN_KEYBOARD_LAYOUT = [
@@ -7,6 +7,14 @@ export const EN_KEYBOARD_LAYOUT = [
   ["q", "w", "e", "r", "t", "y", "u", "i", "o", "p", "[", "]", "\\"],
   ["a", "s", "d", "f", "g", "h", "j", "k", "l", ";", "'"],
   ["z", "x", "c", "v", "b", "n", "m", ",", ".", "/"],
+] as const;
+
+// キーボードレイアウト（ISOキーボード）
+export const ISO_KEYBOARD_LAYOUT = [
+  ["1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "-", "="],
+  ["q", "w", "e", "r", "t", "y", "u", "i", "o", "p", "[", "]"],
+  ["a", "s", "d", "f", "g", "h", "j", "k", "l", ";", "'", "\\"],
+  ["`", "z", "x", "c", "v", "b", "n", "m", ",", ".", "/"],
 ] as const;
 
 // キーボードレイアウト（日本語キーボード）

--- a/src/button-accordion-with-keyboard/features/LeftHandAccordion/Keyboard/consts.ts
+++ b/src/button-accordion-with-keyboard/features/LeftHandAccordion/Keyboard/consts.ts
@@ -1,12 +1,13 @@
 import {
   EN_KEYBOARD_LAYOUT,
+  ISO_KEYBOARD_LAYOUT,
   JA_KEYBOARD_LAYOUT,
 } from "../../../consts/keyboardLayout";
 
 import type { KeyboardLayoutType } from "../../../consts/keyboardLayout";
 
 export type { KeyboardLayoutType };
-export { EN_KEYBOARD_LAYOUT, JA_KEYBOARD_LAYOUT };
+export { EN_KEYBOARD_LAYOUT, ISO_KEYBOARD_LAYOUT, JA_KEYBOARD_LAYOUT };
 
 // Altoの音程の配列（Db, Ab, Eb, Bb, F, C, G, D, A, E, B, F#）
 // A4を基準（0）として半音の差を指定
@@ -31,6 +32,19 @@ EN_KEYBOARD_LAYOUT.forEach((row, rowIndex) => {
   row.forEach((key, colIndex) => {
     if (key !== null) {
       EN_KEY_MAP[key] = { row: rowIndex, col: colIndex };
+    }
+  });
+});
+
+// キーとベースボタンのマッピング（ISOキーボード）
+export const ISO_KEY_MAP: Record<string, { row: number; col: number }> = {};
+ISO_KEYBOARD_LAYOUT.forEach((row, rowIndex) => {
+  row.forEach((key, colIndex) => {
+    if (key !== null) {
+      ISO_KEY_MAP[key] = {
+        row: rowIndex,
+        col: rowIndex === 3 ? colIndex - 1 : colIndex,
+      };
     }
   });
 });

--- a/src/button-accordion-with-keyboard/features/LeftHandAccordion/Keyboard/index.tsx
+++ b/src/button-accordion-with-keyboard/features/LeftHandAccordion/Keyboard/index.tsx
@@ -34,7 +34,7 @@ export const Keyboard = () => {
   const [buttonStates, setButtonStates] = useState<Record<string, boolean>>({});
   const [keyLabelStyle, setKeyLabelStyle] = useState<KeyLabelStyle>("note");
   const [keyboardLayoutType, setKeyboardLayoutType] =
-    useState<KeyboardLayoutType>("iso");
+    useState<KeyboardLayoutType>("en");
 
   const { t } = useTranslation();
   const { playActiveReeds, stopActiveReeds } = usePlayActiveReeds();

--- a/src/button-accordion-with-keyboard/features/LeftHandAccordion/Keyboard/index.tsx
+++ b/src/button-accordion-with-keyboard/features/LeftHandAccordion/Keyboard/index.tsx
@@ -34,7 +34,7 @@ export const Keyboard = () => {
   const [buttonStates, setButtonStates] = useState<Record<string, boolean>>({});
   const [keyLabelStyle, setKeyLabelStyle] = useState<KeyLabelStyle>("note");
   const [keyboardLayoutType, setKeyboardLayoutType] =
-    useState<KeyboardLayoutType>("en");
+    useState<KeyboardLayoutType>("iso");
 
   const { t } = useTranslation();
   const { playActiveReeds, stopActiveReeds } = usePlayActiveReeds();
@@ -143,6 +143,7 @@ export const Keyboard = () => {
             onChange={handleKeyboardLayoutChange}
           >
             <MenuItem value="en">{t("keyboard.layout.en")}</MenuItem>
+            <MenuItem value="iso">{t("keyboard.layout.iso")}</MenuItem>
             <MenuItem value="ja">{t("keyboard.layout.ja")}</MenuItem>
           </Select>
         </FormControl>
@@ -164,7 +165,7 @@ export const Keyboard = () => {
             key={rowIndex}
             style={{
               display: "flex",
-              marginLeft: `${rowIndex * (24 + 2)}px`, // 行が下がるごとに右にずらす
+              marginLeft: `${(keyboardLayoutType === "iso" && rowIndex === 3 ? 1 : rowIndex) * (24 + 2)}px`, // 行が下がるごとに右にずらす
               gap: "4px",
             }}
           >

--- a/src/button-accordion-with-keyboard/features/LeftHandAccordion/Keyboard/utils.ts
+++ b/src/button-accordion-with-keyboard/features/LeftHandAccordion/Keyboard/utils.ts
@@ -2,8 +2,10 @@ import {
   NOTE_LABELS,
   ROOT_NOTES,
   EN_KEYBOARD_LAYOUT,
+  ISO_KEYBOARD_LAYOUT,
   JA_KEYBOARD_LAYOUT,
   EN_KEY_MAP,
+  ISO_KEY_MAP,
   JA_KEY_MAP,
   type KeyboardLayoutType,
 } from "./consts";
@@ -72,11 +74,25 @@ const getNoteIndex = (semitone: number, offset: number = 9): number => {
 
 // キーボードレイアウトの切り替え
 export const getKeyMap = (keyboardLayout: KeyboardLayoutType) => {
-  return keyboardLayout === "en" ? EN_KEY_MAP : JA_KEY_MAP;
+  switch (keyboardLayout) {
+    case "en":
+      return EN_KEY_MAP;
+    case "iso":
+      return ISO_KEY_MAP;
+    case "ja":
+      return JA_KEY_MAP;
+  }
 };
 
 export const getKeyboardLayout = (keyboardLayout: KeyboardLayoutType) => {
-  return keyboardLayout === "en" ? EN_KEYBOARD_LAYOUT : JA_KEYBOARD_LAYOUT;
+  switch (keyboardLayout) {
+    case "en":
+      return EN_KEYBOARD_LAYOUT;
+    case "iso":
+      return ISO_KEYBOARD_LAYOUT;
+    case "ja":
+      return JA_KEYBOARD_LAYOUT;
+  }
 };
 
 // keyから周波数の配列を返す

--- a/src/button-accordion-with-keyboard/features/RightHandAccordion/Keyboard/consts.ts
+++ b/src/button-accordion-with-keyboard/features/RightHandAccordion/Keyboard/consts.ts
@@ -162,7 +162,7 @@ export const ISO_KEY_MAP_C_SYSTEM: Record<string, number> = {
   "'": 16,
   "\\": 19,
   // 4列目
-  "`":-15,
+  "`": -15,
   z: -12,
   x: -9,
   c: -6,
@@ -217,7 +217,7 @@ export const ISO_KEY_MAP_B_SYSTEM: Record<string, number> = {
   "'": 19,
   "\\": 22,
   // 4列目
-  "`":-13,
+  "`": -13,
   z: -10,
   x: -7,
   c: -4,

--- a/src/button-accordion-with-keyboard/features/RightHandAccordion/Keyboard/consts.ts
+++ b/src/button-accordion-with-keyboard/features/RightHandAccordion/Keyboard/consts.ts
@@ -1,12 +1,13 @@
 import {
   EN_KEYBOARD_LAYOUT,
+  ISO_KEYBOARD_LAYOUT,
   JA_KEYBOARD_LAYOUT,
 } from "../../../consts/keyboardLayout";
 
 import type { KeyboardLayoutType } from "../../../consts/keyboardLayout";
 
 export type { KeyboardLayoutType };
-export { EN_KEYBOARD_LAYOUT, JA_KEYBOARD_LAYOUT };
+export { EN_KEYBOARD_LAYOUT, ISO_KEYBOARD_LAYOUT, JA_KEYBOARD_LAYOUT };
 
 // キーボードシステムタイプ（B-systemとC-system）
 export type KeyboardSystemType = "b-system" | "c-system";
@@ -107,6 +108,116 @@ export const EN_KEY_MAP_B_SYSTEM: Record<string, number> = {
   ";": 16,
   "'": 19,
   // 4列目
+  z: -10,
+  x: -7,
+  c: -4,
+  v: -1,
+  b: 2,
+  n: 5,
+  m: 8,
+  ",": 11,
+  ".": 14,
+  "/": 17,
+};
+
+// 右手側キーボードのキーマッピング（C-system, ISOキーボード）
+export const ISO_KEY_MAP_C_SYSTEM: Record<string, number> = {
+  // 1列目
+  "1": -18,
+  "2": -15,
+  "3": -12,
+  "4": -9,
+  "5": -6,
+  "6": -3,
+  "7": 0,
+  "8": 3,
+  "9": 6,
+  "0": 9,
+  "-": 12,
+  "=": 15,
+  // 2列目
+  q: -16,
+  w: -13,
+  e: -10,
+  r: -7,
+  t: -4,
+  y: -1,
+  u: 2,
+  i: 5,
+  o: 8,
+  p: 11,
+  "[": 14,
+  "]": 17,
+  // 3列目
+  a: -14,
+  s: -11,
+  d: -8,
+  f: -5,
+  g: -2,
+  h: 1,
+  j: 4,
+  k: 7,
+  l: 10,
+  ";": 13,
+  "'": 16,
+  "\\": 19,
+  // 4列目
+  "`":-15,
+  z: -12,
+  x: -9,
+  c: -6,
+  v: -3,
+  b: 0,
+  n: 3,
+  m: 6,
+  ",": 9,
+  ".": 12,
+  "/": 15,
+};
+
+// 右手側キーボードのキーマッピング（B-system, ISOキーボード）
+export const ISO_KEY_MAP_B_SYSTEM: Record<string, number> = {
+  // 1列目
+  "1": -13,
+  "2": -10,
+  "3": -7,
+  "4": -4,
+  "5": -1,
+  "6": 2,
+  "7": 5,
+  "8": 8,
+  "9": 11,
+  "0": 14,
+  "-": 17,
+  "=": 20,
+  // 2列目
+  q: -12,
+  w: -9,
+  e: -6,
+  r: -3,
+  t: 0,
+  y: 3,
+  u: 6,
+  i: 9,
+  o: 12,
+  p: 15,
+  "[": 18,
+  "]": 21,
+  // 3列目
+  a: -11,
+  s: -8,
+  d: -5,
+  f: -2,
+  g: 1,
+  h: 4,
+  j: 7,
+  k: 10,
+  l: 13,
+  ";": 16,
+  "'": 19,
+  "\\": 22,
+  // 4列目
+  "`":-13,
   z: -10,
   x: -7,
   c: -4,
@@ -231,6 +342,7 @@ export const JA_KEY_MAP_B_SYSTEM: Record<string, number> = {
 
 // 後方互換性のために元の変数名を維持
 export const EN_KEY_MAP = EN_KEY_MAP_C_SYSTEM;
+export const ISO_KEY_MAP = ISO_KEY_MAP_C_SYSTEM;
 export const JA_KEY_MAP = JA_KEY_MAP_C_SYSTEM;
 
 // 音階の名前のマッピング

--- a/src/button-accordion-with-keyboard/features/RightHandAccordion/Keyboard/index.tsx
+++ b/src/button-accordion-with-keyboard/features/RightHandAccordion/Keyboard/index.tsx
@@ -144,6 +144,7 @@ export const Keyboard: FC = () => {
             onChange={handleKeyboardLayoutChange}
           >
             <MenuItem value="en">{t("keyboard.layout.en")}</MenuItem>
+            <MenuItem value="iso">{t("keyboard.layout.iso")}</MenuItem>
             <MenuItem value="ja">{t("keyboard.layout.ja")}</MenuItem>
           </Select>
         </FormControl>
@@ -157,8 +158,8 @@ export const Keyboard: FC = () => {
             label={t("keyboard.system.label")}
             onChange={handleKeyboardSystemChange}
           >
-            <MenuItem value="c-system">{t("keyboard.system.c")}</MenuItem>
             <MenuItem value="b-system">{t("keyboard.system.b")}</MenuItem>
+            <MenuItem value="c-system">{t("keyboard.system.c")}</MenuItem>
           </Select>
         </FormControl>
       </div>
@@ -180,7 +181,7 @@ export const Keyboard: FC = () => {
             key={rowIndex}
             style={{
               display: "flex",
-              marginLeft: `${rowIndex * (24 + 2)}px`, // 行が下がるごとに右にずらす
+              marginLeft: `${(keyboardLayoutType === "iso" && rowIndex === 3 ? 1 : rowIndex) * (24 + 2)}px`, // 行が下がるごとに右にずらす
               gap: "4px",
             }}
           >

--- a/src/button-accordion-with-keyboard/features/RightHandAccordion/Keyboard/utils.ts
+++ b/src/button-accordion-with-keyboard/features/RightHandAccordion/Keyboard/utils.ts
@@ -2,10 +2,13 @@ import { useCallback } from "react";
 import { useTranslation } from "react-i18next";
 
 import {
-  JA_KEYBOARD_LAYOUT,
   EN_KEYBOARD_LAYOUT,
+  ISO_KEYBOARD_LAYOUT,
+  JA_KEYBOARD_LAYOUT,
   EN_KEY_MAP_C_SYSTEM,
   EN_KEY_MAP_B_SYSTEM,
+  ISO_KEY_MAP_C_SYSTEM,
+  ISO_KEY_MAP_B_SYSTEM,
   JA_KEY_MAP_C_SYSTEM,
   JA_KEY_MAP_B_SYSTEM,
   KEY_LABEL_TEXTS,
@@ -26,13 +29,34 @@ const getKeyMap = (
   systemType: KeyboardSystemType,
 ) => {
   if (systemType === "c-system") {
-    return keyboardLayout === "en" ? EN_KEY_MAP_C_SYSTEM : JA_KEY_MAP_C_SYSTEM;
+    switch (keyboardLayout) {
+      case "en":
+        return EN_KEY_MAP_C_SYSTEM;
+      case "iso":
+        return ISO_KEY_MAP_C_SYSTEM;
+      case "ja":
+        return JA_KEY_MAP_C_SYSTEM;
+    }
   } else {
-    return keyboardLayout === "en" ? EN_KEY_MAP_B_SYSTEM : JA_KEY_MAP_B_SYSTEM;
+    switch (keyboardLayout) {
+      case "en":
+        return EN_KEY_MAP_B_SYSTEM;
+      case "iso":
+          return ISO_KEY_MAP_B_SYSTEM;
+      case "ja":
+        return JA_KEY_MAP_B_SYSTEM;
+    }
   }
 };
 export const getKeyboardLayout = (keyboardLayout: KeyboardLayoutType) => {
-  return keyboardLayout === "en" ? EN_KEYBOARD_LAYOUT : JA_KEYBOARD_LAYOUT;
+  switch (keyboardLayout) {
+    case "en":
+      return EN_KEYBOARD_LAYOUT;
+    case "iso":
+      return ISO_KEYBOARD_LAYOUT;
+    case "ja":
+      return JA_KEYBOARD_LAYOUT;
+  }
 };
 
 // 白鍵の判定用オフセット

--- a/src/button-accordion-with-keyboard/features/RightHandAccordion/Keyboard/utils.ts
+++ b/src/button-accordion-with-keyboard/features/RightHandAccordion/Keyboard/utils.ts
@@ -42,7 +42,7 @@ const getKeyMap = (
       case "en":
         return EN_KEY_MAP_B_SYSTEM;
       case "iso":
-          return ISO_KEY_MAP_B_SYSTEM;
+        return ISO_KEY_MAP_B_SYSTEM;
       case "ja":
         return JA_KEY_MAP_B_SYSTEM;
     }

--- a/src/button-accordion-with-keyboard/locales/en/translation.ts
+++ b/src/button-accordion-with-keyboard/locales/en/translation.ts
@@ -55,8 +55,9 @@ const translation: TranslationResource = {
     },
     layout: {
       label: "Keyboard Layout (QWERTY)",
-      en: "US layout",
-      ja: "Japanese layout",
+      en: "US (ANSI)",
+      iso: "International (ISO)",
+      ja: "Japanese (JIS)",
     },
     system: {
       label: "Keyboard System",

--- a/src/button-accordion-with-keyboard/locales/ja/translation.ts
+++ b/src/button-accordion-with-keyboard/locales/ja/translation.ts
@@ -56,13 +56,14 @@ const translation: TranslationResource = {
     },
     layout: {
       label: "キーボードレイアウト（QWERTY）",
-      en: "US（英字配列）",
-      ja: "JIS（日本語配列）",
+      en: "英字配列（ANSI）",
+      iso: "英字配列（ISO）",
+      ja: "日本語配列（JIS）",
     },
     system: {
       label: "キーボードシステム",
-      c: "C-system",
       b: "B-system",
+      c: "C-system",
     },
     doremi: {
       c: "ド",

--- a/src/button-accordion-with-keyboard/locales/types.ts
+++ b/src/button-accordion-with-keyboard/locales/types.ts
@@ -77,14 +77,15 @@ export type KeyboardViewTranslations = {
 export type KeyboardLayoutTranslations = {
   label: string;
   en: string;
+  iso: string;
   ja: string;
 };
 
 // キーボードシステム関連の型
 export type KeyboardSystemTranslations = {
   label: string;
-  c: string;
   b: string;
+  c: string;
 };
 
 // キーボードノート関連の型


### PR DESCRIPTION
This PR adds an option for the [ISO](https://en.wikipedia.org/wiki/ISO/IEC_9995) keyboard layout (default in Europe), which has an extra key on the bottom row to the left of `Z`.

You can select it from the dropdown along with US (ANSI) and Japanese (JIS).

<img width="753" alt="Screenshot 2025-05-25 at 09 38 16" src="https://github.com/user-attachments/assets/d19387c9-864e-48c8-b3da-0f759ff3bbf1" />

