### PR TITLE
chore: remove deprecated husky v9 boilerplate from commit-msg hook

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,9 +1,1 @@
-#!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
-
 npx --no -- commitlint --edit "$1"
-
-
-
-
-


### PR DESCRIPTION
## 概要

コミットのたびに husky が以下の非推奨警告を出していたので、原因の 2 行を削除しました。

```
husky - DEPRECATED
Please remove the following two lines from .husky/commit-msg:
#!/usr/bin/env sh
. "$(dirname -- "$0")/_/husky.sh"
They WILL FAIL in v10.0.0
```

husky v9 以降はフックスクリプトを直接実行するため、shebang と `husky.sh` の source 行は不要です。実際 `.husky/_/husky.sh` の中身はこの警告を `echo` するだけになっています。

## 変更内容

- `.husky/commit-msg` から shebang と `. "$(dirname -- "$0")/_/husky.sh"` を削除（ついでに末尾の余分な空行も整理）
- `.husky/pre-commit` は既に `npx lint-staged` のみでクリーンだったため変更なし

## 動作確認

`core.hooksPath` がこのリポジトリでは main チェックアウトの `.husky/_` を指す**絶対パス**になっているため、worktree からの素の `git commit` では編集したファイルではなく main 側のフックが実行されてしまいます。そのため `-c core.hooksPath=<worktree>/.husky/_` を指定し、編集後のスクリプトを確実に通す形で検証しました。

- **異常系**（不正なコミットメッセージ + `src/` 配下のファイルを stage）
  - pre-commit: lint-staged が動作し、staged ファイルに対して `biome check` が完了
  - commit-msg: commitlint が `subject-empty` / `type-empty` で拒否（exit 1）
  - **`husky - DEPRECATED` の出力なし**
- **正常系**（本 PR のコミット）
  - commitlint を通過し exit 0、警告なし
  - lint-staged は実行され、`.husky/commit-msg` がどの glob (`*.{jsx,tsx,html}` / `src/**/*`) にも該当しないため "No staged files match" を正しく報告

検証用の一時ファイルと worktree にコピーした `.husky/_` は削除済みです。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
