### PR TITLE
ci: improve repository-wide verification

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -23,5 +23,9 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
       - name: Setup toolchain
         uses: ./.github/actions/setup-node-npm
-      - run: npm run build
-      - run: npm run check
+      - name: Check
+        run: npm run check
+      - name: Test
+        run: npm run test:ci
+      - name: Build
+        run: npm run build

--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.5.5/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.5.10/schema.json",
   "vcs": { "enabled": true, "clientKind": "git", "useIgnoreFile": true },
   "files": {
     "includes": [

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -34,7 +34,7 @@ const getContentType = (filePath: string): string => {
 globalThis.fetch = async (input, init) => {
   const requestUrl = toRequestUrl(input);
   // file:// 以外は既存fetchに委譲し、副作用を最小化する。
-  if (!requestUrl || !requestUrl.startsWith("file://")) {
+  if (!requestUrl?.startsWith("file://")) {
     if (!originalFetch) {
       throw new Error("globalThis.fetch is not available in this environment.");
     }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,8 +2,8 @@ import { resolve } from "node:path";
 import react from "@vitejs/plugin-react";
 import { defineConfig } from "vite";
 
-const root = resolve(__dirname, "src"); // srcフォルダをrootにする。マルチページのフォルダをsrcにまとめたい＆変に階層を増やしたくない。
-const outDir = resolve(__dirname, "dist"); // でも当然ビルドフォルダはsrcの外にしたい
+const root = resolve(import.meta.dirname, "src"); // srcフォルダをrootにする。マルチページのフォルダをsrcにまとめたい＆変に階層を増やしたくない。
+const outDir = resolve(import.meta.dirname, "dist"); // でも当然ビルドフォルダはsrcの外にしたい
 
 export default defineConfig({
   base: "./", // JSのimportが相対パスになる。ビルドしたフォルダ単体で動くので便利。


### PR DESCRIPTION
Busyboxブランチ内で得られたリポジトリ全体向け改善だけを抽出しました。CIにtest:ciを追加し、Biome schemaをCLI 2.5.10へ同期、Jest setupのlint警告を解消、Vite configをimport.meta.dirnameへ移行します。Busybox固有コード・依存・Pages設定は含みません。検証: npm run check、npm run test:ci（24 suites / 222 tests）、npm run build。